### PR TITLE
Fix liens Google Maps sur lieux.html

### DIFF
--- a/lieux.html
+++ b/lieux.html
@@ -70,7 +70,7 @@ permalink: /lieux/
 			</div>
 		</section>
 
-		<a class="first-map-banner" href="//goo.gl/maps/owwhsLHvg3w" target="_blank" rel="noopener" title="Voir le cinéma Le Français sur Google Map">
+		<a class="first-map-banner" href="//goo.gl/NRUIbC" title="Plan d'accès à l'Aquabella sur Google Maps" target="_blank" rel="noopener">
 			<!-- nothing here! -->
 		</a>
 
@@ -111,7 +111,7 @@ permalink: /lieux/
 			</div>
 		</section>
 
-		<a class="second-map-banner" href="//goo.gl/maps/F5N3hXtZmp82" target="_blank" rel="noopener" title="Voir l'école Epitech sur Google Map">
+		<a class="second-map-banner" href="//goo.gl/MZeUAA" title="Plan d'accès à l'ESDAC sur Google Maps" target="_blank" rel="noopener">
 			<!-- nothing here! -->
 		</a>
 	</article>


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?
Sur la page /2017/lieux, les liens en fond de carte pointaient vers les anciens lieux (ceux de Bordeaux)

### Quels sont les changement(s) apporté(s) ?

- Modification de 2 urls

### Qui devrait être prévenu de cette demande ?

@sudweb/thym

Les liens en fond de carte pointaient vers les lieux de l'édition 2016.